### PR TITLE
Add changelog using towncrier

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,43 @@
+name: check-changelog
+
+on:
+  pull_request:
+
+jobs:
+  validate-fragment:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-required') }}
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: pip install towncrier
+      - name: Make sure exactly one valid Towncrier fragment exists
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          dir=changes
+
+          mapfile -t fragments < <(find ${dir} -type f -name "${PR_NUMBER}.*.md" -printf '%P\n')
+
+          count=${#fragments[@]}
+
+          if [ "$count" -eq 1 ]; then
+              echo "Found changelog fragment: ${fragments[0]}"
+          elif [ "$count" -eq 0 ]; then
+              echo "::error::No fragment named '${PR_NUMBER}.*.md' found in '${dir}/'."
+              echo "Check the [changes README](https://github.com/MaMMoS-project/mammos-units/blob/main/changes/README.md) for instructions."
+              exit 1
+          else
+              echo "::error::Multiple fragments for PR #${PR_NUMBER} found; expected exactly one."
+              printf 'Matches:\n%s\n' "${fragments[*]}"
+              exit 1
+          fi
+      - name: Check if a changelog fragment has allowed type
+        run: towncrier check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,11 +30,53 @@ jobs:
       - name: Check that the correct version is pinned in the binder configuration
         run: grep "mammos-units==$VERSION" .binder/environment.yml
 
+  check_changelog:
+    name: Check changelog is up-to-date
+    needs: check_version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check that changes/ is empty
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Count every *.md file except README.md in changes/
+          count=$(find changes -type f -name '*.md' ! -name 'README.md' | wc -l)
+
+          if [ "$count" -ne 0 ]; then
+            echo "::error::There are still $count news fragment(s) in 'changes/'."
+            echo "Run 'towncrier build' and commit the updated CHANGELOG.md."
+            exit 1
+          fi
+          echo "No news fragments left in changes/"
+      - name: Check CHANGELOG.md heading
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Extract the first level 2 heading
+          first_h2=$(grep -o -m1 -E "^## \[blaupause .*\]" CHANGELOG.md || true)
+
+          if [ -z "$first_h2" ]; then
+            echo "::error::No level-2 (##) heading found in CHANGELOG.md."
+            exit 1
+          fi
+
+          echo "First heading in CHANGELOG.md: '$first_h2'"
+
+          expected="## [blaupause $GITHUB_REF_NAME]"
+          if [ "$first_h2" != "$expected" ]; then
+            echo "::error::First heading must start with '$expected'"
+            exit 1
+          fi
+
+          echo "✔ CHANGELOG heading matches the pushed tag ($GITHUB_REF_NAME)"
+
   publish-to-pypi:
     name: Publish to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish on tag pushes
     needs:
-      - check_version
+      - check_changelog
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in [changes](changes).
+
+<!-- towncrier release notes start -->
+
+

--- a/changes/32.misc.md
+++ b/changes/32.misc.md
@@ -1,0 +1,1 @@
+Use [towncrier](https://towncrier.readthedocs.io) to generate changelog from fragments. Each new PR must include a changelog fragment.

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,72 @@
+# News fragments
+
+This directory contains news fragments for unreleased changes that will be
+processed with [towncrier](https://towncrier.readthedocs.io/) to create a new
+section in the the top-level [CHANGELOG file](../CHANGELOG.md).
+
+## Creating a PR
+
+Most PRs should be mentioned in the changelog. As part of the PR you need to
+create a changelog fragment in the changes/ directory (where this README
+resides). The file name must be `<PR number>.<type>.md`. CI will check that the
+file exists and has an appropriate name. The content must be markdown. It should
+NOT start with a bullet point and NOT reference the pull request as both will be
+added by towncrier automatically.
+
+Allowed types are:
+- added
+- changed
+- deprecated
+- removed
+- fixed
+- misc
+
+misc can be used for all internal changes that are not directly relevant to
+users, e.g. refactoring, work on the CI, other repository infrastructure, ...
+
+If a PR should not appear in the changelog add the label
+`no-changelog-entry-required` to the PR.
+
+### Examples
+
+Assume we have two PRs:
+
+1. A new feature has been added in PR 1.
+
+   Add a file with name `1.added.md` with content:
+
+   ```markdown
+   A new feature X has been added to support use case Y.
+   ```
+
+2. Changes to the CI have been made in PR 2.
+
+   Add a file with name `2.misc.md` with content:
+
+   ```markdown
+   Refactoring of the CI to increase parallelisation.
+   ```
+
+This will result in the following additions to the changelog (assuming we
+release this as mammos-units version 0.1.0):
+
+```markdown
+## [mammos-units 0.1.0](<url to 0.1.0 tag>) – <release date>
+
+### Added
+
+- A new feature X has been added to support use case Y. ([#1](<url to PR 1>))
+
+### Misc
+
+- Refactoring of the CI to increase parallelisation. ([#2](<url to PR 2>))
+```
+
+## Making a release
+
+When releasing bump the package version and subsequently run `towncrier build`
+in the root directory to convert all changelog fragments into a new section in
+the toplevel CHANGELOG file. Commit changes in the changelog file and
+automatically removed fragment files prior to tagging the release.
+
+To preview the changes run `towncrier build --draft`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ packaging = "<25"
 pre-commit = "*"
 pytest = "*"
 ruff = "*"
+towncrier = "*"
 
 [tool.pixi.pypi-dependencies]
 mammos-units = { path = ".", editable = true }
@@ -83,3 +84,41 @@ test-docstrings = "pytest -v --doctest-modules src/mammos_units"
 test-notebooks = "pytest -v --nbval-lax examples"
 test-all = { depends-on = ["test-unittest", "test-docstrings", "test-notebooks"] }
 style = "pre-commit run --all-files"
+
+[tool.towncrier]
+directory = "changes"
+filename = "CHANGELOG.md"
+package = "mammos_units"
+title_format = "## [mammos-units {version}](https://github.com/MaMMoS-project/mammos-units/tree/{version}) – {project_date}"
+# point to PRs instead of issues; CI ensures that the correct PR numbers exist
+issue_format = "[#{issue}](https://github.com/MaMMoS-project/mammos-units/pull/{issue})"
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Misc"
+showcontent = true


### PR DESCRIPTION
- changelog fragments must be added to changes/
- instructions are given in changes/README.md
- CI to check that the fragment is present in PRs (not using https://github.com/scientific-python/action-towncrier-changelog/, because their code seems a bit fragile and has some inconveniencies [slow, non-standard, pulls config from main branch])
- if a PR does not need a changelog entry add the label `no-changelog-entry-required`
- CI to check that changelog is up-to-date when releasing

I have tested the new setup in https://github.com/lang-m/blaupause.